### PR TITLE
reset property next_upgrade

### DIFF
--- a/space-panels_1.0.2/prototypes/space-panels.lua
+++ b/space-panels_1.0.2/prototypes/space-panels.lua
@@ -93,6 +93,7 @@ local function create_directional_panel(cdir)
         panel.selection_box = {{-0.4, -3.5}, {14.5, 3.5}}
         panel.collision_box = {{-0.4, -3.4}, {14.4, 3.4}}	
 	end
+	panel.next_upgrade = nil
 	return panel
 end
   


### PR DESCRIPTION
Factorio crashes at startup time when installed together with https://mods.factorio.com/mod/alien-module (Alien Loot Economy):

Error ModManager.cpp:1765: Error while running setup for entity prototype "space-solar-panel-east" (solar-panel): next_upgrade target (alien-solarpanel) must have the same fast_replaceable_group (solar-panel != space-solar-panel).

Probably because they add a next_upgrade to the solar-panel: https://codeberg.org/renoth/factorio-alien-module/src/commit/1ded98245296d9470d9c1fa46e52e18f3b1eda96/alien-module/prototypes/entity/entity.lua#L57

And I guess removing that again for the your panels after deep-copying them from solar-panel should work...